### PR TITLE
Use one style of imports

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,10 +15,9 @@ Quick Start
 .. code:: python
 
     import twitter_ads
-    from twitter_ads import *
 
     # initialize the client
-    client = Client(
+    client = twitter_ads.Client(
       consumer_key, consumer_secret, access_token,
       access_token_secret, sandbox=True)
 


### PR DESCRIPTION
`import twitter_ads` was not used and doing `from twitter_ads import *` [is not good practice](http://stackoverflow.com/a/2386740) - so I got rid of the `import *` line.

We could use `from twitter_ads import Client` as well, but I prefer being explicit to avoid any collisions with other libraries that might have a `Client`.