### PR TITLE
Adding tweet preview support

### DIFF
--- a/examples/tweet_preview.py
+++ b/examples/tweet_preview.py
@@ -1,0 +1,35 @@
+from twitter_ads.client import Client
+from twitter_ads.tweet import Tweet
+
+CONSUMER_KEY = 'your consumer key'
+CONSUMER_SECRET = 'your consumer secret'
+ACCESS_TOKEN = 'access token'
+ACCESS_TOKEN_SECRET = 'access token secret'
+ACCOUNT_ID = 'account id'
+
+# initialize the client
+client = Client(
+    CONSUMER_KEY, CONSUMER_SECRET, ACCESS_TOKEN, ACCESS_TOKEN_SECRET)
+
+# load the advertiser account instance
+account = client.accounts().next()
+
+# create an instance of our Tweet container
+tweet = Tweet(account)
+
+# preview an existing Tweet
+tweet.get_preview(id=661845592138776576)
+
+# preview a new Tweet
+tweet.get_preview(status="Hello World!")
+
+# preview a new Tweet with an image
+tweet.get_preview(status="Hello World!", media_ids=634458428836962304)
+
+# preview a new Tweet with multiple images (up to 4)
+images = [
+  634458428836962305, 634458428836962306,
+  634458428836962307, 634458428836962308
+]
+
+tweet.get_preview(status="Hello World!", media_ids=images)

--- a/twitter_ads/tweet.py
+++ b/twitter_ads/tweet.py
@@ -1,0 +1,41 @@
+# Copyright (C) 2015 Twitter, Inc.
+
+"""Container for all Tweet-related logic used by the Ads API SDK."""
+
+from twitter_ads.resource import resource, Resource
+from twitter_ads.http import Request
+
+
+@resource
+class Tweet(Resource):
+
+    PROPERTIES = {
+        'platform': {'readonly': True},
+        'preview': {'readonly': True}
+    }
+
+    TWEET_PREVIEW = '/0/accounts/{account_id}/tweet/preview'
+    TWEET_EXISTS_PREVIEW = '/0/accounts/{account_id}/tweet/preview/{tweet_id}'
+
+    def __init__(self, account):
+        self._account = account
+
+    @property
+    def account(self):
+        return self._account
+
+    def get_preview(self, id=None, **kwargs):
+        """
+        Returns an HTML preview of a tweet, either new or existing.
+        """
+        if id is not None:
+            resource = self.TWEET_EXISTS_PREVIEW.format(
+                account_id=self.account.id, tweet_id=id)
+        else:
+            resource = self.TWEET_PREVIEW.format(
+                account_id=self.account.id)
+
+        response = Request(
+            self._account.client(), 'get', resource, params=kwargs).perform()
+
+        return response.body['data']


### PR DESCRIPTION
I took the same approach as you did for the [scoped timeline endpoint](https://github.com/twitterdev/twitter-python-ads-sdk/blob/master/twitter_ads/account.py#L135-L152) because it's a very similar concept in terms of what the function of these endpoints is. I am aware that the [Ruby implementation](https://github.com/twitterdev/twitter-ruby-ads-sdk/blob/master/lib/twitter-ads/tweet.rb) takes a slightly different approach - if you think that's a better take on doing tweet previews, let me know and I'll make the necessary changes.

I also added a couple of examples in `quick_start.py`.

In terms of tests, I wasn't sure whether I should go ahead and start creating a test suite myself - it's probably best I leave that to you and once that's in place I can add tests for this :)

Closes #12.