### PR TITLE
Improve SDK reference documentation before v0.1.0 release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# Virtualenv
+sdk/

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -19,7 +19,7 @@ import shlex
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-sys.path.insert(0, os.path.abspath('..'))
+sys.path.insert(0, os.path.abspath('../../twitter_ads'))
 
 # -- General configuration ------------------------------------------------
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,6 +6,9 @@
    :hidden:
 
    twitter_ads/index
+   twitter_ads/code
+   twitter_ads/account
+   twitter_ads/audience
    twitter_ads/error
 
 Getting Started

--- a/docs/source/twitter_ads/account.rst
+++ b/docs/source/twitter_ads/account.rst
@@ -1,0 +1,5 @@
+:mod:`account`
+============================
+
+.. automodule:: account
+   :members:

--- a/docs/source/twitter_ads/audience.rst
+++ b/docs/source/twitter_ads/audience.rst
@@ -1,0 +1,5 @@
+:mod:`audience`
+============================
+
+.. automodule:: audience
+   :members:

--- a/docs/source/twitter_ads/campaign.rst
+++ b/docs/source/twitter_ads/campaign.rst
@@ -1,0 +1,5 @@
+:mod:`campaign`
+============================
+
+.. automodule:: campaign
+   :members:

--- a/docs/source/twitter_ads/client.rst
+++ b/docs/source/twitter_ads/client.rst
@@ -1,0 +1,5 @@
+:mod:`client`
+============================
+
+.. automodule:: client
+   :members:

--- a/docs/source/twitter_ads/creative.rst
+++ b/docs/source/twitter_ads/creative.rst
@@ -1,0 +1,5 @@
+:mod:`creative`
+============================
+
+.. automodule:: creative
+   :members:

--- a/docs/source/twitter_ads/cursor.rst
+++ b/docs/source/twitter_ads/cursor.rst
@@ -1,0 +1,5 @@
+:mod:`cursor`
+============================
+
+.. automodule:: cursor
+   :members:

--- a/docs/source/twitter_ads/enum.rst
+++ b/docs/source/twitter_ads/enum.rst
@@ -1,0 +1,5 @@
+:mod:`enum`
+============================
+
+.. automodule:: enum
+   :members:

--- a/docs/source/twitter_ads/error.rst
+++ b/docs/source/twitter_ads/error.rst
@@ -1,6 +1,6 @@
-:mod:`error` -- Module for all error types raised by the SDK
+:mod:`error`
 ============================================================
 
-.. automodule:: twitter_ads.error
+.. automodule:: error
    :synopsis: Module for all error types raised by the SDK.
    :members:

--- a/docs/source/twitter_ads/http.rst
+++ b/docs/source/twitter_ads/http.rst
@@ -1,0 +1,5 @@
+:mod:`http`
+============================
+
+.. automodule:: http
+   :members:

--- a/docs/source/twitter_ads/resource.rst
+++ b/docs/source/twitter_ads/resource.rst
@@ -1,0 +1,5 @@
+:mod:`resource`
+============================
+
+.. automodule:: resource
+   :members:

--- a/docs/source/twitter_ads/targeting.rst
+++ b/docs/source/twitter_ads/targeting.rst
@@ -1,0 +1,5 @@
+:mod:`targeting`
+============================
+
+.. automodule:: targeting
+   :members:

--- a/docs/source/twitter_ads/tweet.rst
+++ b/docs/source/twitter_ads/tweet.rst
@@ -1,0 +1,5 @@
+:mod:`tweet`
+============================
+
+.. automodule:: tweet
+   :members:

--- a/docs/source/twitter_ads/utils.rst
+++ b/docs/source/twitter_ads/utils.rst
@@ -1,0 +1,5 @@
+:mod:`utils`
+============================
+
+.. automodule:: utils
+   :members:


### PR DESCRIPTION
Docstrings need to include references to dev.twitter.com resources and usage examples. See the Ruby SDK for an example of what we're looking for.

Please reference this issue in related PRs to track the effort.