### PR TITLE
Implement First to Cursor

### DIFF
--- a/twitter_ads/cursor.py
+++ b/twitter_ads/cursor.py
@@ -43,6 +43,13 @@ class Cursor(object):
         return self._total_count or len(self._collection)
 
     @property
+    def first(self):
+        """
+        Returns the first item of available items available to the cursor instance.
+        """
+        return next(iter(self._collection), None)
+
+    @property
     def fetched(self):
         """
         Returns the number of items fetched so far.


### PR DESCRIPTION
Suggesting that we add a .first method to the cursor. For a very basic demo it seems like it might be cleaner to have a method to pull the first item.

**Scenario**
I think this would be useful when querying "accounts". Although many users have multiple accounts, for a demo it seems like it would be easier to use.

**Example**
```
account = client.accounts().first
```

**Testing**
Tested this locally on a fork via https://github.com/garethpaul/twitter-python-ads-sdk/blob/gpj_cursor_first/twitter_ads/cursor.py#L46

Per the guidelines for contributing, let me know if this sounds like something you think would be useful and I'll add a pull request. 