### PR TITLE
Implement TON Upload Support

### DIFF
--- a/examples/quick_start.py
+++ b/examples/quick_start.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime
 
 from twitter_ads.client import Client
 from twitter_ads.campaign import Campaign, LineItem, TargetingCriteria
@@ -22,7 +22,7 @@ campaign.funding_instrument_id = account.funding_instruments().next().id
 campaign.daily_budget_amount_local_micro = 1000000
 campaign.name = 'my first campaign'
 campaign.paused = True
-campaign.start_time = datetime.datetime.utcnow()
+campaign.start_time = datetime.utcnow()
 campaign.save()
 
 # create a line item for the campaign

--- a/twitter_ads/__init__.py
+++ b/twitter_ads/__init__.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2015 Twitter, Inc.
 
-VERSION = (0, 1, 3)
+VERSION = (0, 2, 0)
 
 from twitter_ads.utils import get_version
 

--- a/twitter_ads/audience.py
+++ b/twitter_ads/audience.py
@@ -4,6 +4,9 @@
 
 from twitter_ads.enum import TA_OPERATIONS, TRANSFORM
 from twitter_ads.resource import resource_property, Resource
+from twitter_ads.http import TONUpload, Request
+from twitter_ads.error import BadRequest
+from twitter_ads.cursor import Cursor
 
 
 class TailoredAudience(Resource):
@@ -17,30 +20,75 @@ class TailoredAudience(Resource):
 
     @classmethod
     def create(klass, account, file_path, name, list_type):
-        raise NotImplementedError
+        """
+        Uploads and creates a new tailored audience.
+        """
+        upload = TONUpload(account.client, file_path)
+        audience = klass(account)
+        getattr(audience, '__create_audience__')(name, list_type)
+        try:
+            getattr(audience, '__update_audience__')(upload.perform(), list_type, TA_OPERATIONS.ADD)
+            return audience.reload()
+        except BadRequest as e:
+            audience.delete()
+            raise e
 
     @classmethod
     def opt_out(klass, account, file_path, list_type):
-        raise NotImplementedError
+        """
+        Updates the global opt-out list for the specified advertiser account.
+        """
+        upload = TONUpload(account.client, file_path)
+        params = {'input_file_path': upload.perform(), 'list_type': list_type}
+        resource = klass.OPT_OUT.format(account_id=account.id)
+        Request(account.client, 'put', resource, params=params).perform()
+        return True
 
     def update(self, file_path, list_type, operation=TA_OPERATIONS.ADD):
         """
         Updates the current tailored audience instance.
         """
-        raise NotImplementedError
+        upload = TONUpload(self.account.client, file_path)
+        getattr(self, '__update_audience__')(upload.perform(), list_type, operation)
+        return self.reload()
 
     def delete(self):
         """
         Deletes the current tailored audience instance.
         """
-        raise NotImplementedError
+        resource = self.RESOURCE.format(account_id=self.account.id, id=self.id)
+        response = Request(self.account.client, 'delete', resource).perform()
+        return self.from_response(response.body['data'])
 
     def status(self):
         """
-        Returns the status of all changes for the current tailored
-        audience instance.
+        Returns the status of all changes for the current tailored audience instance.
         """
-        raise NotImplementedError
+        if not self.id:
+            return None
+
+        resource = self.RESOURCE_UPDATE.format(account_id=self.account.id)
+        request = Request(self.account.client, 'get', resource, params=self.to_params())
+        cursor = list(Cursor(None, request))
+
+        return filter(lambda change: change['tailored_audience_id'] == self.id, cursor)
+
+    def __create_audience__(self, name, list_type):
+        params = {'name': name, 'list_type': list_type}
+        resource = self.RESOURCE_COLLECTION.format(account_id=self.account.id)
+        response = Request(self.account.client, 'post', resource, params=params).perform()
+        return self.from_response(response.body['data'])
+
+    def __update_audience__(self, location, list_type, operation):
+        params = {
+            'tailored_audience_id': self.id,
+            'input_file_path': location,
+            'list_type': list_type,
+            'operation': operation
+        }
+
+        resource = self.RESOURCE_UPDATE.format(account_id=self.account.id)
+        return Request(self.account.client, 'post', resource, params=params).perform()
 
 # tailored audience properties
 # read-only

--- a/twitter_ads/error.py
+++ b/twitter_ads/error.py
@@ -9,7 +9,11 @@ class Error(Exception):
     def __init__(self, response, **kwargs):
         self._response = response
         self._code = kwargs.get('code', response.code)
-        self._details = kwargs.get('details', response.body.get('errors', None))
+
+        if response.body and 'errors' in response.body:
+            self._details = kwargs.get('details', response.body.get('errors'))
+        else:
+            self._details = None
 
     @property
     def response(self):
@@ -30,6 +34,9 @@ class Error(Exception):
             code=getattr(self, 'code'),
             details=getattr(self, 'details')
         )
+
+    def __str__(self):
+        return self.__repr__()
 
     @staticmethod
     def from_response(response):

--- a/twitter_ads/http.py
+++ b/twitter_ads/http.py
@@ -2,10 +2,11 @@
 
 """Container for all HTTP request and response logic for the SDK."""
 
+import os
 import sys
 import platform
-import datetime
 import logging
+import json
 
 try:
     import httplib2 as httplib
@@ -15,11 +16,12 @@ except ImportError:
     else:
         import http.client as httplib
 
+import dateutil.parser
+from datetime import datetime, timedelta
 
-from dateutil import parser
 from requests_oauthlib import OAuth1Session
 
-from twitter_ads.utils import get_version
+from twitter_ads.utils import get_version, http_time
 from twitter_ads.error import Error
 
 
@@ -29,11 +31,24 @@ class Request(object):
     _DEFAULT_DOMAIN = 'https://ads-api.twitter.com'
     _SANDBOX_DOMAIN = 'https://ads-api-sandbox.twitter.com'
 
+    _HTTP_METHOD = [
+        'get',
+        'put',
+        'post',
+        'delete',
+    ]
+
     def __init__(self, client, method, resource, **kwargs):
         self._client = client
-        self._method = method.lower()
         self._resource = resource
         self._options = kwargs.copy()
+
+        method = method.lower()
+        if method not in self._HTTP_METHOD:
+            msg = "Error! {0} is not an allowed HTTP method type.".format(method)
+            raise ValueError(msg)
+
+        self._method = method
 
     @property
     def options(self):
@@ -78,7 +93,7 @@ class Request(object):
         response = method(url, headers=headers, data=data, params=params)
 
         return Response(response.status_code, response.headers,
-                        body=response.json(), raw_body=response.text)
+                        body=response.raw, raw_body=response.text)
 
     def __enable_logging(self):
         httplib.HTTPConnection.debuglevel = 1
@@ -106,19 +121,20 @@ class Response(object):
         self._code = code
         self._headers = headers
         self._raw_body = kwargs.get('raw_body', None)
-        self._body = kwargs.get('body', None) or self._raw_body
+
+        try:
+            self._body = json.loads(self._raw_body)
+        except ValueError:
+            self._body = self._raw_body
 
         if 'x-rate-limit-reset' in headers:
             self._rate_limit = int(headers['x-rate-limit-limit'])
             self._rate_limit_remaining = int(headers['x-rate-limit-remaining'])
-            self._rate_limit_reset = datetime.datetime.fromtimestamp(
-                int(headers['x-rate-limit-reset']))
+            self._rate_limit_reset = datetime.fromtimestamp(int(headers['x-rate-limit-reset']))
         elif 'x-cost-rate-limit-reset' in headers:
             self._rate_limit = int(headers['x-cost-rate-limit-limit'])
-            self._rate_limit_remaining = int(
-                headers['x-cost-rate-limit-remaining'])
-            self._rate_limit_reset = parser.parse(
-                headers['x-cost-rate-limit-reset'].first)
+            self._rate_limit_remaining = int(headers['x-cost-rate-limit-remaining'])
+            self._rate_limit_reset = dateutil.parser.parse(headers['x-cost-rate-limit-reset'].first)
         else:
             self._rate_limit = None
             self._rate_limit_remaining = None
@@ -155,3 +171,130 @@ class Response(object):
     @property
     def error(self):
         return True if (self._code >= 400 and self._code <= 599) else False
+
+
+class TONUpload(object):
+    """Specialized request class for TON API uploads."""
+
+    _DEFAULT_DOMAIN = 'https://ton.twitter.com'
+    _DEFAULT_RESOURCE = '/1.1/ton/bucket/'
+    _DEFAULT_BUCKET = 'ta_partner'
+    _DEFAULT_EXPIRE = datetime.now() + timedelta(days=10)
+    _MIN_FILE_SIZE = 1024 * 1024 * 1
+
+    def __init__(self, client, file_path, **kwargs):
+        if not os.path.isfile(file_path):
+            msg = "Error! The specified file does not exist. ({0})".format(file_path)
+            raise ValueError(msg)
+
+        self._file_path = os.path.abspath(file_path)
+        self._file_size = os.path.getsize(self._file_path)
+        self._client = client
+        self._options = kwargs.copy()
+        self._bucket = self._options.pop('bucket', self._DEFAULT_BUCKET)
+
+    @property
+    def options(self):
+        return self._options
+
+    @property
+    def client(self):
+        return self._client
+
+    @property
+    def bucket(self):
+        return self._bucket
+
+    @property
+    def content_type(self):
+        """Returns the content-type value determined by file extension."""
+
+        if hasattr(self, '_content_type'):
+            return self._content_type
+
+        filename, extension = os.path.splitext(self._file_path)
+        if extension == '.csv':
+            self._content_type = 'text/csv'
+        elif extension == '.tsv':
+            self._content_type = 'text/tab-separated-values'
+        else:
+            self._content_type = 'text/plain'
+
+        return self._content_type
+
+    def perform(self):
+        """Executes the current TONUpload object."""
+
+        if self._file_size < self._MIN_FILE_SIZE:
+            resource = "{0}{1}".format(self._DEFAULT_RESOURCE, self.bucket)
+            response = self.__upload(resource, open(self._file_path, 'rb').read())
+            return response.headers['location']
+        else:
+            response = self.__init_chunked_upload()
+            chunk_size = int(response.headers['x-ton-min-chunk-size'])
+            location = response.headers['location']
+
+            f = open(self._file_path, 'rb')
+            bytes_read = 0
+            while True:
+                bytes = f.read(chunk_size)
+                if not bytes:
+                    break
+                bytes_start = bytes_read
+                bytes_read += len(bytes)
+                self.__upload_chunk(location, chunk_size, bytes, bytes_start, bytes_read)
+            f.close()
+
+            return location
+
+    def __repr__(self):
+        return '<{name} object at {mem} bucket={bucket} file={file}>'.format(
+            name=self.__class__.__name__,
+            mem=hex(id(self)),
+            bucket=self.bucket,
+            file=self._file_path
+        )
+
+    def __upload(self, resource, bytes):
+        """Performs a single chunk upload."""
+
+        # note: string conversion required here due to open encoding bug in requests-oauthlib.
+        headers = {
+            'x-ton-expires': http_time(self.options.get('x-ton-expires', self._DEFAULT_EXPIRE)),
+            'content-length': str(self._file_size),
+            'content-type': self.content_type
+        }
+
+        return Request(self._client, 'post', resource,
+                       domain=self._DEFAULT_DOMAIN, headers=headers, body=bytes).perform()
+
+    def __init_chunked_upload(self):
+        """Initialization for a multi-chunk upload."""
+
+        # note: string conversion required here due to open encoding bug in requests-oauthlib.
+        headers = {
+            'x-ton-content-type': self.content_type,
+            'x-ton-content-length': str(self._file_size),
+            'x-ton-expires': http_time(self.options.get('x-ton-expires', self._DEFAULT_EXPIRE)),
+            'content-length': str(0),
+            'content-type': self.content_type
+        }
+
+        resource = "{0}{1}?resumable=true".format(self._DEFAULT_RESOURCE, self._DEFAULT_BUCKET)
+
+        return Request(self._client, 'post', resource,
+                       domain=self._DEFAULT_DOMAIN, headers=headers).perform()
+
+    def __upload_chunk(self, resource, chunk_size, bytes, bytes_start, bytes_read):
+        """Uploads a single chunk of a multi-chunk upload."""
+
+        # note: string conversion required here due to open encoding bug in requests-oauthlib.
+        headers = {
+            'content-type': self.content_type,
+            'content-length': str(min([chunk_size, self._file_size - bytes_read])),
+            'content-range': "bytes {0}-{1}/{2}".format(
+                bytes_start, bytes_read - 1, self._file_size)
+        }
+
+        return Request(self._client, 'put', resource,
+                       domain=self._DEFAULT_DOMAIN, headers=headers, body=bytes).perform()

--- a/twitter_ads/resource.py
+++ b/twitter_ads/resource.py
@@ -2,8 +2,8 @@
 
 """Container for all plugable resource object logic used by the Ads API SDK."""
 
-import datetime
 import dateutil.parser
+from datetime import datetime, timedelta
 
 from twitter_ads.utils import format_time, to_time
 from twitter_ads.enum import TRANSFORM, GRANULARITY
@@ -69,7 +69,7 @@ class Resource(object):
             if value is None:
                 continue
 
-            if isinstance(value, datetime.datetime):
+            if isinstance(value, datetime):
                 params[name] = format_time(value)
             elif isinstance(value, list):
                 params[name] = ','.join(map(str, value))
@@ -185,8 +185,8 @@ class Analytics(object):
         """
         Pulls a list of metrics for a specified set of object IDs.
         """
-        end_time = kwargs.get('end_time', datetime.datetime.utcnow())
-        start_time = kwargs.get('start_time', end_time - datetime.timedelta(seconds=604800))
+        end_time = kwargs.get('end_time', datetime.utcnow())
+        start_time = kwargs.get('start_time', end_time - timedelta(seconds=604800))
         granularity = kwargs.get('granularity', GRANULARITY.HOUR)
         segmentation_type = kwargs.get('segmentation_type', None)
 

--- a/twitter_ads/utils.py
+++ b/twitter_ads/utils.py
@@ -2,26 +2,30 @@
 
 """Container for all helpers and utilities used throughout the Ads API SDK."""
 
-import datetime
+from datetime import timedelta
+from email.utils import formatdate
+from time import mktime
 
 from twitter_ads import VERSION
 from twitter_ads.enum import GRANULARITY
 
 
 def get_version():
+    """Returns a string representation of the current SDK version."""
     if isinstance(VERSION[-1], str):
         return '.'.join(map(str, VERSION[:-1])) + VERSION[-1]
     return '.'.join(map(str, VERSION))
 
 
 def to_time(time, granularity):
+    """Returns a truncated and rounded time string based on the specified granularity."""
     if not granularity:
         return format_time(time)
     if granularity == GRANULARITY.HOUR:
-        return format_time(time - datetime.timedelta(
+        return format_time(time - timedelta(
             minutes=time.minute, seconds=time.second, microseconds=time.microsecond))
     elif granularity == GRANULARITY.DAY:
-        return format_time(time - datetime.timedelta(
+        return format_time(time - timedelta(
             hours=time.hour, minutes=time.minute,
             seconds=time.second, microseconds=time.microsecond))
     else:
@@ -29,4 +33,10 @@ def to_time(time, granularity):
 
 
 def format_time(time):
+    """Formats a datetime as an ISO 8601 compliant string."""
     return time.strftime('%Y-%m-%dT%H:%M:%SZ')
+
+
+def http_time(time):
+    """Formats a datetime as an RFC 1123 compliant string."""
+    return formatdate(timeval=mktime(time.timetuple()), localtime=False, usegmt=True)


### PR DESCRIPTION
Implement support for [TON uploads](https://dev.twitter.com/rest/ton) in a `TONUpload` class in `twitter_ads.http`. Under the hood it will use the `Request` class. 

Once this is built, we need to implement `create`, `update` and `optout` methods on the `TailoredAudience` class which all take a file path as an input param.

https://github.com/twitterdev/twitter-python-ads-sdk/blob/master/twitter_ads/audience.py#L40-L65

- [x] Implement `twitter_ads.http.TONUpload`
- [x] Implement `twitter_ads.audience.TailoredAudience`