### PR TITLE
Fixing `AttributeError` when importing `httplib2`

### DIFF
--- a/twitter_ads/http.py
+++ b/twitter_ads/http.py
@@ -9,13 +9,10 @@ import logging
 import json
 import zlib
 
-try:
-    import httplib2 as httplib
-except ImportError:
-    if sys.version_info[0] != 3:
-        import httplib
-    else:
-        import http.client as httplib
+if sys.version_info[0] != 3:
+    import httplib
+else:
+    import http.client as httplib
 
 import dateutil.parser
 from datetime import datetime, timedelta


### PR DESCRIPTION
Seeing the following error when using the `trace=True` when instantiating a `Client` object&mdash;only when `httplib2` is installed in the current Python environment:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/jshishido/.virtualenvs/fix-httplib2-py2/lib/python2.7/site-packages/twitter_ads/client.py", line 89, in accounts
    return Account.load(self, id) if id else Account.all(self)
  File "/Users/jshishido/.virtualenvs/fix-httplib2-py2/lib/python2.7/site-packages/twitter_ads/account.py", line 46, in load
    response = Request(client, 'get', resource, params=kwargs).perform()
  File "/Users/jshishido/.virtualenvs/fix-httplib2-py2/lib/python2.7/site-packages/twitter_ads/http.py", line 72, in perform
    self.__enable_logging()
  File "/Users/jshishido/.virtualenvs/fix-httplib2-py2/lib/python2.7/site-packages/twitter_ads/http.py", line 106, in __enable_logging
    httplib.HTTPConnection.debuglevel = 1
AttributeError: 'module' object has no attribute 'HTTPConnection'
```

We don't actually need `httplib2`&mdash;removing from `twitter_ads/http.py`.

Tested using both Python 2.7 and Python 3.5 with the following packages installed:

```
$ pip list
appdirs (1.4.3)
oauthlib (2.0.2)
packaging (16.8)
pip (9.0.1)
pyparsing (2.2.0)
python-dateutil (2.6.0)
requests (2.13.0)
requests-oauthlib (0.8.0)
setuptools (34.4.0)
six (1.10.0)
wheel (0.30.0a0)
```