### PR TITLE
Dynamic chunk size

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,8 @@
 import datetime
+from random import randint
 
 from twitter_ads.enum import GRANULARITY
-from twitter_ads.utils import to_time
+from twitter_ads.utils import size, to_time
 
 
 t = datetime.datetime(2006, 3, 21, 0, 0, 0)
@@ -10,3 +11,18 @@ def test_to_time_based_on_granularity():
     for g in [None, GRANULARITY.HOUR, GRANULARITY.TOTAL]:
         assert to_time(t, g) == '2006-03-21T00:00:00Z'
     assert to_time(t, GRANULARITY.DAY) == '2006-03-21'
+
+def test_sizes():
+    _DEFAULT_CHUNK_SIZE = 64
+    _RESPONSE_TIME_MAX = 5000
+    for _ in range(10):
+        response_time = randint(0, _RESPONSE_TIME_MAX)
+        assert size(_DEFAULT_CHUNK_SIZE, _RESPONSE_TIME_MAX, response_time) == _DEFAULT_CHUNK_SIZE
+    response_times = {10000 : 32,
+                      20000 : 16,
+                      40000 : 8,
+                      80000 : 4,
+                      160000 : 2,
+                      320000 : 1}
+    for rt in response_times:
+        assert size(_DEFAULT_CHUNK_SIZE, _RESPONSE_TIME_MAX, rt) == response_times[rt]

--- a/twitter_ads/utils.py
+++ b/twitter_ads/utils.py
@@ -47,7 +47,9 @@ def http_time(time):
     """Formats a datetime as an RFC 1123 compliant string."""
     return formatdate(timeval=mktime(time.timetuple()), localtime=False, usegmt=True)
 
+
 def size(default_chunk_size, response_time_max, response_time_actual):
+    """Determines the chunk size based on response times."""
     if response_time_actual == 0:
         response_time_actual = 1
     scale = 1 / (response_time_actual / response_time_max)

--- a/twitter_ads/utils.py
+++ b/twitter_ads/utils.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2015 Twitter, Inc.
+from __future__ import division
 
 """Container for all helpers and utilities used throughout the Ads API SDK."""
 
@@ -45,3 +46,10 @@ def format_date(time):
 def http_time(time):
     """Formats a datetime as an RFC 1123 compliant string."""
     return formatdate(timeval=mktime(time.timetuple()), localtime=False, usegmt=True)
+
+def size(default_chunk_size, response_time_max, response_time_actual):
+    if response_time_actual == 0:
+        response_time_actual = 1
+    scale = 1 / (response_time_actual / response_time_max)
+    size = int(default_chunk_size * scale)
+    return min(max(size, 1), default_chunk_size)


### PR DESCRIPTION
### Context

This addresses issues such as [this one](https://twittercommunity.com/t/rate-limited-when-uploading-a-tailored-audience-using-python/91085), where SDK users are being rate limited when sending large audience files.

### The problem with the current implementation

The `TONUpload`'s [`perform` method](https://github.com/twitterdev/twitter-python-ads-sdk/blob/master/twitter_ads/http.py#L240-L263) initiates a chunked upload when the input file is greater than or equal to `_MIN_FILE_SIZE`, currently set at 64 MB (`1024 * 1024 * 64`). The problem is that it sends `x-ton-min-chunk-size`-sized (1 MB) chunks. This means a 63 MB file, because it follows the [single-upload](https://dev.twitter.com/rest/ton/single-chunk) path, will only make two requests to the `1.1/ton/bucket/ta_partner` endpoint&mdash;the initial POST and the subsequent PUT&mdash;while a 65 MB file will make 66 requests to the same endpoint.

### Proposal

For chunked uploads, choose the chunk size based on:

* `_RESPONSE_TIME_MAX`
* `x-response-time`

I've defined a 5-second threshold (`_RESPONSE_TIME_MAX = 5000`). When the response time for the *previous* request is less than or equal to that value, we send a max-sized chunk (64 MB, for example). Otherwise, we scale it based on the inverse of the actual response time divided by the threshold. With the 5-second max, if the previous request took 10 seconds, the chunk will be 32 MB (assuming the 64 MB default).