### PR TITLE
Scheduled Tweets

### DIFF
--- a/examples/scheduled_tweet.py
+++ b/examples/scheduled_tweet.py
@@ -20,3 +20,6 @@ scheduled_tweet = ScheduledTweet(account)
 scheduled_tweet.text = 'Future'
 scheduled_tweet.scheduled_at = datetime.utcnow() + timedelta(days=2)
 scheduled_tweet.save()
+
+# preview
+scheduled_tweet.preview()

--- a/examples/scheduled_tweet.py
+++ b/examples/scheduled_tweet.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta
 
 from twitter_ads.client import Client
+from twitter_ads.campaign import LineItem, ScheduledPromotedTweet
 from twitter_ads.creative import ScheduledTweet
 
 CONSUMER_KEY = 'your consumer key'
@@ -23,3 +24,10 @@ scheduled_tweet.save()
 
 # preview
 scheduled_tweet.preview()
+
+# associate with a line item
+account.line_items().next().id
+scheduled_promoted_tweet = ScheduledPromotedTweet(account)
+scheduled_promoted_tweet.line_item_id = line_item_id
+scheduled_promoted_tweet.scheduled_tweet_id = scheduled_tweet.id
+scheduled_promoted_tweet.save()

--- a/examples/scheduled_tweet.py
+++ b/examples/scheduled_tweet.py
@@ -1,0 +1,22 @@
+from datetime import datetime, timedelta
+
+from twitter_ads.client import Client
+from twitter_ads.creative import ScheduledTweet
+
+CONSUMER_KEY = 'your consumer key'
+CONSUMER_SECRET = 'your consumer secret'
+ACCESS_TOKEN = 'access token'
+ACCESS_TOKEN_SECRET = 'access token secret'
+ACCOUNT_ID = 'account id'
+
+# initialize the client
+client = Client(CONSUMER_KEY, CONSUMER_SECRET, ACCESS_TOKEN, ACCESS_TOKEN_SECRET)
+
+# load the advertiser account instance
+account = client.accounts(ACCOUNT_ID)
+
+# create the Scheduled Tweet
+scheduled_tweet = ScheduledTweet(account)
+scheduled_tweet.text = 'Future'
+scheduled_tweet.scheduled_at = datetime.utcnow() + timedelta(days=2)
+scheduled_tweet.save()

--- a/twitter_ads/account.py
+++ b/twitter_ads/account.py
@@ -12,8 +12,8 @@ from twitter_ads.resource import resource_property, Resource
 from twitter_ads.creative import (AccountMedia, MediaCreative, ScheduledTweet,
                                   Video, VideoWebsiteCard)
 from twitter_ads.audience import TailoredAudience
-from twitter_ads.campaign import (FundingInstrument, Campaign, LineItem,
-                                  AppList, PromotableUser)
+from twitter_ads.campaign import (AppList, Campaign, FundingInstrument, LineItem,
+                                  PromotableUser, ScheduledPromotedTweet)
 
 
 class Account(Resource):
@@ -142,6 +142,12 @@ class Account(Resource):
         Returns a collection of Scheduled Tweets available to the current account.
         """
         return self._load_resource(ScheduledTweet, id, **kwargs)
+
+    def scheduled_promoted_tweets(self, id=None, **kwargs):
+        """
+        Returns a collection of Scheduled Promoted Tweets available to the current account.
+        """
+        return self._load_resource(ScheduledPromotedTweet, id, **kwargs)
 
     def video_website_cards(self, id=None, **kwargs):
         """

--- a/twitter_ads/account.py
+++ b/twitter_ads/account.py
@@ -9,7 +9,8 @@ from twitter_ads.cursor import Cursor
 from twitter_ads import API_VERSION
 
 from twitter_ads.resource import resource_property, Resource
-from twitter_ads.creative import AccountMedia, MediaCreative, Video, VideoWebsiteCard
+from twitter_ads.creative import (AccountMedia, MediaCreative, ScheduledTweet,
+                                  Video, VideoWebsiteCard)
 from twitter_ads.audience import TailoredAudience
 from twitter_ads.campaign import (FundingInstrument, Campaign, LineItem,
                                   AppList, PromotableUser)
@@ -135,6 +136,12 @@ class Account(Resource):
         Returns a collection of media creatives available to the current account.
         """
         return self._load_resource(MediaCreative, id, **kwargs)
+
+    def scheduled_tweets(self, id=None, **kwargs):
+        """
+        Returns a collection of Scheduled Tweets available to the current account.
+        """
+        return self._load_resource(ScheduledTweet, id, **kwargs)
 
     def video_website_cards(self, id=None, **kwargs):
         """

--- a/twitter_ads/campaign.py
+++ b/twitter_ads/campaign.py
@@ -199,6 +199,25 @@ resource_property(LineItem, 'bid_type')
 resource_property(LineItem, 'to_delete', transform=TRANSFORM.BOOL)
 
 
+class ScheduledPromotedTweet(Resource, Persistence):
+
+    PROPERTIES = {}
+
+    RESOURCE_COLLECTION = '/' + API_VERSION + '/accounts/{account_id}/scheduled_promoted_tweets'
+    RESOURCE = '/' + API_VERSION + '/accounts/{account_id}/scheduled_promoted_tweets/{id}'
+
+# scheduled promoted tweets properties
+# read-only
+resource_property(ScheduledPromotedTweet, 'created_at', readonly=True, transform=TRANSFORM.TIME)
+resource_property(ScheduledPromotedTweet, 'deleted', readonly=True, transform=TRANSFORM.BOOL)
+resource_property(ScheduledPromotedTweet, 'id', readonly=True)
+resource_property(ScheduledPromotedTweet, 'tweet_id', readonly=True)
+resource_property(ScheduledPromotedTweet, 'updated_at', readonly=True, transform=TRANSFORM.TIME)
+# writable
+resource_property(ScheduledPromotedTweet, 'line_item_id')
+resource_property(ScheduledPromotedTweet, 'scheduled_tweet_id')
+
+
 class Tweet(object):
 
     TWEET_PREVIEW = '/' + API_VERSION + '/accounts/{account_id}/tweet/preview'

--- a/twitter_ads/creative.py
+++ b/twitter_ads/creative.py
@@ -360,3 +360,31 @@ resource_property(VideoConversationCard, 'thank_you_text')
 resource_property(VideoConversationCard, 'thank_you_url')
 resource_property(VideoConversationCard, 'image_media_id')
 resource_property(VideoConversationCard, 'video_id')
+
+
+class ScheduledTweet(Resource, Persistence):
+
+    PROPERTIES = {}
+
+    RESOURCE_COLLECTION = '/' + API_VERSION + '/accounts/{account_id}/scheduled_tweets'
+    RESOURCE = '/' + API_VERSION + '/accounts/{account_id}/scheduled_tweets/{id}'
+
+# scheduled tweet properties
+# read-only
+resource_property(ScheduledTweet, 'created_at', readonly=True, transform=TRANSFORM.TIME)
+resource_property(ScheduledTweet, 'completed_at', read_only=True, transform=TRANSFORM.TIME)
+resource_property(ScheduledTweet, 'id', read_only=True)
+resource_property(ScheduledTweet, 'id_str', read_only=True)
+resource_property(ScheduledTweet, 'media_keys', readonly=True)
+resource_property(ScheduledTweet, 'scheduled_status', read_only=True)
+resource_property(ScheduledTweet, 'tweet_id', readonly=True)
+resource_property(ScheduledTweet, 'updated_at', readonly=True, transform=TRANSFORM.TIME)
+resource_property(ScheduledTweet, 'user_id', read_only=True)
+#writable
+resource_property(ScheduledTweet, 'as_user_id')
+resource_property(ScheduledTweet, 'card_uri')
+resource_property(ScheduledTweet, 'media_ids', transform=TRANSFORM.LIST)
+resource_property(ScheduledTweet, 'nullcast', transform=TRANSFORM.BOOL)
+resource_property(ScheduledTweet, 'scheduled_at', transform=TRANSFORM.TIME)
+resource_property(ScheduledTweet, 'text')
+

--- a/twitter_ads/creative.py
+++ b/twitter_ads/creative.py
@@ -368,6 +368,17 @@ class ScheduledTweet(Resource, Persistence):
 
     RESOURCE_COLLECTION = '/' + API_VERSION + '/accounts/{account_id}/scheduled_tweets'
     RESOURCE = '/' + API_VERSION + '/accounts/{account_id}/scheduled_tweets/{id}'
+    PREVIEW = '/' + API_VERSION + '/accounts/{account_id}/scheduled_tweets/preview/{id}'
+
+    def preview(self):
+        """
+        Returns an HTML preview for a Scheduled Tweet.
+        """
+        if self.id:
+            resource = self.PREVIEW
+            resource = resource.format(account_id=self.account.id, id=self.id)
+            response = Request(self.account.client, 'get', resource).perform()
+            return response.body['data']
 
 # scheduled tweet properties
 # read-only
@@ -387,4 +398,3 @@ resource_property(ScheduledTweet, 'media_ids', transform=TRANSFORM.LIST)
 resource_property(ScheduledTweet, 'nullcast', transform=TRANSFORM.BOOL)
 resource_property(ScheduledTweet, 'scheduled_at', transform=TRANSFORM.TIME)
 resource_property(ScheduledTweet, 'text')
-

--- a/twitter_ads/creative.py
+++ b/twitter_ads/creative.py
@@ -386,7 +386,7 @@ resource_property(ScheduledTweet, 'created_at', readonly=True, transform=TRANSFO
 resource_property(ScheduledTweet, 'completed_at', read_only=True, transform=TRANSFORM.TIME)
 resource_property(ScheduledTweet, 'id', read_only=True)
 resource_property(ScheduledTweet, 'id_str', read_only=True)
-resource_property(ScheduledTweet, 'media_keys', readonly=True)
+resource_property(ScheduledTweet, 'media_keys', readonly=True, transform=TRANSFORM.LIST)
 resource_property(ScheduledTweet, 'scheduled_status', read_only=True)
 resource_property(ScheduledTweet, 'tweet_id', readonly=True)
 resource_property(ScheduledTweet, 'updated_at', readonly=True, transform=TRANSFORM.TIME)

--- a/twitter_ads/creative.py
+++ b/twitter_ads/creative.py
@@ -391,7 +391,7 @@ resource_property(ScheduledTweet, 'scheduled_status', read_only=True)
 resource_property(ScheduledTweet, 'tweet_id', readonly=True)
 resource_property(ScheduledTweet, 'updated_at', readonly=True, transform=TRANSFORM.TIME)
 resource_property(ScheduledTweet, 'user_id', read_only=True)
-#writable
+# writable
 resource_property(ScheduledTweet, 'as_user_id')
 resource_property(ScheduledTweet, 'card_uri')
 resource_property(ScheduledTweet, 'media_ids', transform=TRANSFORM.LIST)


### PR DESCRIPTION
Scheduled Tweets

* add `ScheduledTweet` class to creative.py
    * **Note**: The interface is consistent with the existing ads entities, where the `save` method is used; it does not use the `create` method.
* add `scheduled_tweets` method under the `Account` class to retrieve Scheduled Tweets belonging to the current account
* add `preview` method under the `ScheduledTweet` class

Scheduled Promoted Tweets

* add 'ScheduledPromotedTweet` class to campaign.py
* add scheduled_promoted_tweets` method under the `Account` class to retrieve Scheduled Promoted Tweets belonging to the current account

Also, added a Scheduled Tweets example: creating and promoting it.