### PR TITLE
Include currency as a read-only campaign property

### DIFF
--- a/twitter_ads/campaign.py
+++ b/twitter_ads/campaign.py
@@ -138,6 +138,7 @@ class Campaign(Resource, Persistence, Analytics, Batch):
 # campaign properties
 # read-only
 resource_property(Campaign, 'created_at', readonly=True, transform=TRANSFORM.TIME)
+resource_property(Campaign, 'currency', readonly=True)
 resource_property(Campaign, 'deleted', readonly=True, transform=TRANSFORM.BOOL)
 resource_property(Campaign, 'id', readonly=True)
 resource_property(Campaign, 'reasons_not_servable', readonly=True)


### PR DESCRIPTION
See [this forum thread](https://twittercommunity.com/t/campaign-object-has-no-attribute-currency-twitter-ads-1-2-3/99610).