### PR TITLE
Return False instead of None

### DIFF
--- a/twitter_ads/resource.py
+++ b/twitter_ads/resource.py
@@ -22,7 +22,7 @@ def resource_property(klass, name, **kwargs):
     klass.PROPERTIES[name] = kwargs
 
     def getter(self):
-        return getattr(self, '_%s' % name, kwargs.get('default', None))
+        return getattr(self, '_%s' % name, kwargs.get('default', False))
 
     if kwargs.get('readonly', False):
         setattr(klass, name, property(getter))


### PR DESCRIPTION
We currently return `None` when response attributes are false:

```python
>>> line_items = LineItem(account).all(account, **{"line_item_ids": "5yy8i,5tddn", "with_deleted": "true"})
>>> for e in line_items:
...     print(e.id, e.deleted)
(u'5tddn', None)
(u'5yy8i', True)
```

After the change:

```python
>>> line_items = LineItem(account).all(account, **{"line_item_ids": "5yy8i,5tddn", "with_deleted": "true"})
>>> for e in line_items:
...     print(e.id, e.deleted)
(u'5tddn', False) # correctly displayed as `False`
(u'5yy8i', True)
```