### PR TITLE
Revert "Return False instead of None (#147)"

### DIFF
--- a/twitter_ads/resource.py
+++ b/twitter_ads/resource.py
@@ -22,7 +22,7 @@ def resource_property(klass, name, **kwargs):
     klass.PROPERTIES[name] = kwargs
 
     def getter(self):
-        return getattr(self, '_%s' % name, kwargs.get('default', False))
+        return getattr(self, '_%s' % name, kwargs.get('default', None))
 
     if kwargs.get('readonly', False):
         setattr(klass, name, property(getter))


### PR DESCRIPTION
This reverts commit fd7b860810e40caa80ff038faba79124c24560d6.

#147 causes problems when writable fields can be empty.

For example, with poll cards, `media_key` is optional. When creating a poll card without media, we get the following error.

```
---------------------------------------------------------------------------
BadRequest                                Traceback (most recent call last)
<ipython-input-7-aabd56408a20> in <module>()
----> 1 pc.save()

/Users/jshishido/workspace/twitter-python-ads-sdk/twitter_ads/resource.pyc in save(self)
    199         response = Request(
    200             self.account.client, method,
--> 201             resource, params=self.to_params()).perform()
    202 
    203         return self.from_response(response.body['data'])

/Users/jshishido/workspace/twitter-python-ads-sdk/twitter_ads/http.pyc in perform(self)
     70         response = self.__oauth_request()
     71         if response.code > 399:
---> 72             raise Error.from_response(response)
     73         return response
     74 

BadRequest: <BadRequest object at 0x103693eb0 code=400 details=[{u'message': u'false is not a promoted poll media', u'code': u'INVALID_POLL_MEDIA', u'parameter': u''}]>
```