### PR TITLE
Support Python 3.5+ and drop 3.3/3.4 (EOL)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: python
 
 branches:
@@ -10,13 +11,13 @@ matrix:
   include:
     - python: 2.7
       script: python setup.py flake8 && python setup.py test
-    - python: 3.3
-      script: python setup.py test
-    - python: 3.4
-      script: python setup.py test
     - python: 3.5
-      script: python setup.py test
+      script: python setup.py flake8 && python setup.py test
+    - python: 3.6
+      script: python setup.py flake8 && python setup.py test
+    - python: 3.7
+      script: python setup.py flake8 && python setup.py test
     - python: pypy
       script: python setup.py flake8 && python setup.py test
     - python: pypy3
-      script: pip install setuptools_scm && python setup.py test 
+      script: python setup.py flake8 && python setup.py test 

--- a/README.rst
+++ b/README.rst
@@ -66,9 +66,9 @@ versions we officially support and regularly test against.
 +------------+-------------------------+
 | Platform   | Versions                |
 +============+=========================+
-| CPython    | 2.7, 3.3, 3.4, 3.5      |
+| CPython    | 2.7, 3.5, 3.6, 3.7      |
 +------------+-------------------------+
-| PyPy       | 2.x, 4.x                |
+| PyPy       | 7.x                     |
 +------------+-------------------------+
 
 All releases adhere to strict `semantic versioning`_. For Example,

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,5 +7,5 @@ universal = 1
 [flake8]
 filename = *.py, twitter-ads
 exclude = docs/*
-ignore = F403,E402
+ignore = F403,E402,W504
 max-line-length = 100

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 # Copyright (C) 2015 Twitter, Inc.
 
 import os
-import sys
 from setuptools import setup, find_packages
 
 DESCRIPTION = 'A Twitter supported and maintained Ads API SDK for Python.'
@@ -29,8 +28,9 @@ CLASSIFIERS = [
     'Programming Language :: Python',
     'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.3',
-    'Programming Language :: Python :: 3.4',
+    'Programming Language :: Python :: 3.5',
+    'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: Implementation :: CPython',
     'Programming Language :: Python :: Implementation :: PyPy',
     'Topic :: Internet',
@@ -39,17 +39,9 @@ CLASSIFIERS = [
 ]
 
 extra_opts = {
-    'setup_requires': [],
+    'setup_requires': ['flake8==3.7.7', 'pytest-runner'],
     'tests_require': ['pytest', 'responses', 'mock']
 }
-
-if sys.version_info[:2] == (3, 3):
-    extra_opts['setup_requires'].append('pytest-runner<=3.0.1')
-else:
-    extra_opts['setup_requires'].append('pytest-runner')
-
-if sys.version_info[0] != 3:
-    extra_opts['setup_requires'].append('flake8<=2.6.2')
 
 setup(
     name='twitter-ads',


### PR DESCRIPTION
### Related issue/PR
https://github.com/twitterdev/twitter-python-ads-sdk/issues/181
https://github.com/twitterdev/twitter-python-ads-sdk/pull/182
https://github.com/twitterdev/twitter-python-ads-sdk/issues/185