### PR TITLE
Bug fixes in Analytics class

### DIFF
--- a/examples/analytics.py
+++ b/examples/analytics.py
@@ -49,6 +49,6 @@ job_id = queued_job['id']
 seconds = 15
 time.sleep(seconds)
 
-async_stats_job_result = LineItem.async_stats_job_result(account, job_id)
+async_stats_job_result = LineItem.async_stats_job_result(account, [job_id]).first
 
 async_data = LineItem.async_stats_job_data(account, async_stats_job_result['url'])

--- a/twitter_ads/resource.py
+++ b/twitter_ads/resource.py
@@ -285,18 +285,19 @@ class Analytics(object):
         return response.body['data']
 
     @classmethod
-    def async_stats_job_result(klass, account, job_id, **kwargs):
+    def async_stats_job_result(klass, account, job_ids=None, **kwargs):
         """
         Returns the results of the specified async job IDs
         """
-        params = {
-            'job_ids': job_id
-        }
+        params = {}
+        params.update(kwargs)
+        if isinstance(job_ids, list):
+            params['job_ids'] = ','.join(map(str, job_ids))
 
         resource = klass.RESOURCE_ASYNC.format(account_id=account.id)
-        response = Request(account.client, 'get', resource, params=params).perform()
+        request = Request(account.client, 'get', resource, params=params)
 
-        return response.body['data'][0]
+        return Cursor(klass, request, init_with=[account])
 
     @classmethod
     def async_stats_job_data(klass, account, url, **kwargs):

--- a/twitter_ads/resource.py
+++ b/twitter_ads/resource.py
@@ -332,6 +332,12 @@ class Analytics(object):
             'end_time': to_time(end_time, None)
         }
 
+        for k in kwargs:
+            if isinstance(kwargs[k], list):
+                params[k] = ','.join(map(str, kwargs[k]))
+            else:
+                params[k] = kwargs[k]
+
         resource = klass.RESOURCE_ACTIVE_ENTITIES.format(account_id=account.id)
         response = Request(account.client, 'get', resource, params=params).perform()
         return response.body['data']


### PR DESCRIPTION
1. `active_entities()` method is not handling optional parameters correctly and hence all optional parameters are not working when specified (such as `campaign_ids`).

2. `async_stats_job_result()` is not returning Cursor instance and taking `job_ids` as a required parameter mistakenly.