### PR TITLE
let Analytics class use resource_property()

### DIFF
--- a/examples/analytics.py
+++ b/examples/analytics.py
@@ -51,4 +51,4 @@ time.sleep(seconds)
 
 async_stats_job_result = LineItem.async_stats_job_result(account, [job_id]).first
 
-async_data = LineItem.async_stats_job_data(account, async_stats_job_result['url'])
+async_data = LineItem.async_stats_job_data(account, async_stats_job_result.url)

--- a/tests/test_analytics_async.py
+++ b/tests/test_analytics_async.py
@@ -58,8 +58,8 @@ def test_analytics_async():
         [job_id]).first
 
     assert job_result is not None
-    assert isinstance(job_result, dict)
-    assert job_result['url'] == 'https://ton.twimg.com/advertiser-api-async-analytics/stats.json.gz'
+    assert isinstance(job_result, Analytics)
+    assert job_result.url == 'https://ton.twimg.com/advertiser-api-async-analytics/stats.json.gz'
 
     # call async_stats_job_result() from Analytics class directly
     job_result = Analytics.async_stats_job_result(
@@ -67,5 +67,5 @@ def test_analytics_async():
         [job_id]).first
 
     assert job_result is not None
-    assert isinstance(job_result, dict)
-    assert job_result['url'] == 'https://ton.twimg.com/advertiser-api-async-analytics/stats.json.gz'
+    assert isinstance(job_result, Analytics)
+    assert job_result.url == 'https://ton.twimg.com/advertiser-api-async-analytics/stats.json.gz'

--- a/twitter_ads/campaign.py
+++ b/twitter_ads/campaign.py
@@ -148,7 +148,7 @@ resource_property(TargetingCriteria, 'tailored_audience_type')
 resource_property(TargetingCriteria, 'to_delete', transform=TRANSFORM.BOOL)
 
 
-class FundingInstrument(Resource, Persistence, Analytics):
+class FundingInstrument(Analytics, Resource, Persistence):
 
     PROPERTIES = {}
 
@@ -226,7 +226,7 @@ resource_property(AppList, 'name', readonly=True)
 resource_property(AppList, 'apps', readonly=True)
 
 
-class Campaign(Resource, Persistence, Analytics, Batch):
+class Campaign(Analytics, Resource, Persistence, Batch):
 
     PROPERTIES = {}
 
@@ -259,7 +259,7 @@ resource_property(Campaign, 'total_budget_amount_local_micro')
 resource_property(Campaign, 'to_delete', transform=TRANSFORM.BOOL)
 
 
-class LineItem(Resource, Persistence, Analytics, Batch):
+class LineItem(Analytics, Resource, Persistence, Batch):
 
     PROPERTIES = {}
 

--- a/twitter_ads/creative.py
+++ b/twitter_ads/creative.py
@@ -32,7 +32,7 @@ resource_property(PromotedAccount, 'line_item_id')
 resource_property(PromotedAccount, 'user_id')
 
 
-class PromotedTweet(Resource, Persistence, Analytics):
+class PromotedTweet(Analytics, Resource, Persistence):
 
     PROPERTIES = {}
 
@@ -91,7 +91,7 @@ resource_property(AccountMedia, 'media_id')
 resource_property(AccountMedia, 'video_id')
 
 
-class MediaCreative(Resource, Persistence, Analytics):
+class MediaCreative(Analytics, Resource, Persistence):
 
     PROPERTIES = {}
 

--- a/twitter_ads/resource.py
+++ b/twitter_ads/resource.py
@@ -212,10 +212,12 @@ class Persistence(object):
         self.from_response(response.body['data'])
 
 
-class Analytics(object):
+class Analytics(Resource):
     """
     Container for all analytics related logic used by API resource objects.
     """
+    PROPERTIES = {}
+
     ANALYTICS_MAP = {
         'Campaign': ENTITY.CAMPAIGN,
         'FundingInstrument': ENTITY.FUNDING_INSTRUMENT,
@@ -297,7 +299,7 @@ class Analytics(object):
         resource = klass.RESOURCE_ASYNC.format(account_id=account.id)
         request = Request(account.client, 'get', resource, params=params)
 
-        return Cursor(None, request, init_with=[account])
+        return Cursor(Analytics, request, init_with=[account])
 
     @classmethod
     def async_stats_job_data(klass, account, url, **kwargs):
@@ -341,3 +343,14 @@ class Analytics(object):
         resource = klass.RESOURCE_ACTIVE_ENTITIES.format(account_id=account.id)
         response = Request(account.client, 'get', resource, params=params).perform()
         return response.body['data']
+
+
+# async_stats_job_result() properties
+# read-only
+resource_property(Analytics, 'id', readonly=True)
+resource_property(Analytics, 'id_str', readonly=True)
+resource_property(Analytics, 'status', readonly=True)
+resource_property(Analytics, 'url', readonly=True)
+resource_property(Analytics, 'created_at', readonly=True)
+resource_property(Analytics, 'expires_at', readonly=True)
+resource_property(Analytics, 'updated_at', readonly=True)


### PR DESCRIPTION
In order to allow accessing response data through instance variables, `Analytics` class needs to inherit `Resouce` class but it will produce [MRO error](https://stackoverflow.com/questions/29214888/typeerror-cannot-create-a-consistent-method-resolution-order-mro) so it also needs to change the order of base classes in some classes that inherit `Analytics` class.