### PR TITLE
introduce PromotedTweet.attach() method

### DIFF
--- a/examples/promoted_tweet.py
+++ b/examples/promoted_tweet.py
@@ -8,32 +8,32 @@ CONSUMER_KEY = 'your consumer key'
 CONSUMER_SECRET = 'your consumer secret'
 ACCESS_TOKEN = 'user access token'
 ACCESS_TOKEN_SECRET = 'user access token secret'
-ADS_ACCOUNT = 'ads account id'
+ACCOUNT_ID = 'ads account id'
 
 # initialize the twitter ads api client
 client = Client(CONSUMER_KEY, CONSUMER_SECRET, ACCESS_TOKEN, ACCESS_TOKEN_SECRET)
 
 # load up the account instance, campaign and line item
-account = client.accounts(ADS_ACCOUNT)
+account = client.accounts(ACCOUNT_ID)
 campaign = account.campaigns().next()
 line_item = account.line_items(None, campaign_ids=campaign.id).next()
 
 # create request for a simple nullcasted tweet
 tweet1 = Tweet.create(account, text='There can be only one...')
 
-# promote the tweet using our line item
-promoted_tweet = PromotedTweet(account)
-promoted_tweet.line_item_id = line_item.id
-promoted_tweet.tweet_id = tweet1['id']
-promoted_tweet.save()
-
 # create request for a nullcasted tweet with a website card
 website_card = WebsiteCard.all(account).next()
-text = "Fine. There can be two. {card_url}".format(card_url=website_card.preview_url)
-tweet2 = Tweet.create(account, text)
+tweet2 = Tweet.create(account, text='Fine. There can be two.', card_uri=website_card.card_uri)
 
 # promote the tweet using our line item
-promoted_tweet = PromotedTweet(account)
-promoted_tweet.line_item_id = line_item.id
-promoted_tweet.tweet_id = tweet2['id']
-promoted_tweet.save()
+tweet_ids = [tweet1['id'], tweet2['id']]
+
+response = PromotedTweet.attach(
+    account,
+    line_item_id=line_item.id,
+    tweet_ids=tweet_ids
+)
+
+for i in response:
+    print(i.id)
+    print(i.tweet_id)

--- a/tests/fixtures/promoted_tweets_attach.json
+++ b/tests/fixtures/promoted_tweets_attach.json
@@ -1,0 +1,25 @@
+{
+  "data_type": "promoted_tweet",
+  "data": [
+    {
+      "line_item_id": "2b7xw",
+      "id": "6thl4",
+      "entity_status": "ACTIVE",
+      "created_at": "2015-04-11T20:50:25Z",
+      "updated_at": "2015-04-11T20:50:25Z",
+      "approval_status": "ACCEPTED",
+      "tweet_id": "585127452231467008",
+      "deleted": false
+    }
+  ],
+  "request": {
+    "params": {
+      "line_item_id": "2b7xw",
+      "tweet_ids": [
+        585127452231467008
+      ],
+      "account_id": "2iqph"
+    }
+  },
+  "total_count": 1
+}

--- a/tests/test_promoted_tweets.py
+++ b/tests/test_promoted_tweets.py
@@ -65,3 +65,34 @@ def test_promoted_tweets_load():
     promoted_tweet = PromotedTweet.load(account, '6thl4')
     assert promoted_tweet.id == '6thl4'
     assert promoted_tweet.entity_status == 'ACTIVE'
+
+
+@responses.activate
+def test_promoted_tweets_attach():
+    responses.add(responses.GET,
+                  with_resource('/' + API_VERSION + '/accounts/2iqph'),
+                  body=with_fixture('accounts_load'),
+                  content_type='application/json')
+
+    responses.add(responses.POST,
+                  with_resource('/' + API_VERSION + '/accounts/2iqph/promoted_tweets'),
+                  body=with_fixture('promoted_tweets_attach'),
+                  content_type='application/json')
+
+    client = Client(
+        characters(40),
+        characters(40),
+        characters(40),
+        characters(40)
+    )
+
+    account = Account.load(client, '2iqph')
+    response = PromotedTweet.attach(
+        account,
+        line_item_id='2b7xw',
+        tweet_ids=['585127452231467008']
+    )
+
+    assert isinstance(response, Cursor)
+    assert response.count == 1
+    assert response.first.id == '6thl4'

--- a/twitter_ads/creative.py
+++ b/twitter_ads/creative.py
@@ -2,6 +2,7 @@
 
 """Container for all creative management logic used by the Ads API SDK."""
 
+from requests.exceptions import HTTPError
 from twitter_ads import API_VERSION
 from twitter_ads.cursor import Cursor
 from twitter_ads.enum import TRANSFORM
@@ -38,6 +39,26 @@ class PromotedTweet(Analytics, Resource, Persistence):
     RESOURCE_COLLECTION = '/' + API_VERSION + '/accounts/{account_id}/promoted_tweets'
     RESOURCE = '/' + API_VERSION + '/accounts/{account_id}/promoted_tweets/{id}'
 
+    @Deprecated('This method has been deprecated and will no longer be available '
+                'in the next major version update. Please use PromotedTweet.attach() '
+                'method instead.')
+    def save(self):
+        """
+        Saves or updates the current object instance depending on the
+        presence of `object.id`.
+        """
+        params = self.to_params()
+        if 'tweet_id' in params:
+            params['tweet_ids'] = [params['tweet_id']]
+            del params['tweet_id']
+
+        if self.id:
+            raise HTTPError("Method PUT not allowed.")
+
+        resource = self.RESOURCE_COLLECTION.format(account_id=self.account.id)
+        response = Request(self.account.client, 'post', resource, params=params).perform()
+        return self.from_response(response.body['data'][0])
+
     @classmethod
     def attach(klass, account, line_item_id=None, tweet_ids=None):
         """
@@ -60,8 +81,8 @@ resource_property(PromotedTweet, 'deleted', readonly=True, transform=TRANSFORM.B
 resource_property(PromotedTweet, 'entity_status', readonly=True)
 resource_property(PromotedTweet, 'id', readonly=True)
 resource_property(PromotedTweet, 'updated_at', readonly=True, transform=TRANSFORM.TIME)
-resource_property(PromotedTweet, 'tweet_id', readonly=True)
-resource_property(PromotedTweet, 'line_item_id', readonly=True)
+resource_property(PromotedTweet, 'tweet_id')
+resource_property(PromotedTweet, 'line_item_id')
 
 
 class AccountMedia(Resource, Persistence):


### PR DESCRIPTION
See APE-557

Deprecate `.save()` method and introduce new `PromotedTweet.attach()` class method instead. The naming of "save" was a bit confusing given its actual functionality.

This is a breaking change.
\* I'll put a note about this change in https://github.com/twitterdev/twitter-python-ads-sdk/wiki/Release-Notes

## before
Can only associate a given tweet_id per call:
```py
promoted_tweet = PromotedTweet(account)
promoted_tweet.line_item_id = 'aaaa'  # a line_item_id
promoted_tweet.tweet_id = '111111111111111111'  # a tweet_id
promoted_tweet.save()
```

## after
Can associate given tweet_ids (list, max 50 ids) at once:
```py
# return Cursor object
response = PromotedTweet.attach(
    account,
    line_item_id='aaaa',
    tweet_ids=['111111111111111111', '222222222222222222' ... ]
)

```