### PR TITLE
adding support for private header

### DIFF
--- a/twitter_ads/http.py
+++ b/twitter_ads/http.py
@@ -74,6 +74,10 @@ class Request(object):
         if 'headers' in self.options:
             headers.update(self.options['headers'].copy())
 
+        # internal-only
+        if 'x-as-user' in self._client.options:
+            headers['x-as-user'] = self._client.options.get('x-as-user')
+
         params = self.options.get('params', None)
         data = self.options.get('body', None)
         files = self.options.get('files', None)


### PR DESCRIPTION
@jbabichjapan Could you please review this since you asked me to add this? Thanks

```py
client = Client(
    CONSUMER_KEY,
    CONSUMER_SECRET,
    ACCESS_TOKEN,
    ACCESS_TOKEN_SECRET
    options={
        'x-as-user': 'user_name'
    })
```