### PR TITLE
Add timeout option to Request class for better error handling.

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -59,10 +59,11 @@ def test_accounts_with_options():
             'handle_rate_limit': True,
             'retry_max': 1,
             'retry_delay': 3000,
-            'retry_on_status': [404, 500, 503]
+            'retry_on_status': [404, 500, 503],
+            'timeout': (1.0, 3.0)
         }
     )
 
     assert client is not None
     assert isinstance(client, Client)
-    assert len(client.options) == 4
+    assert len(client.options) == 5

--- a/twitter_ads/http.py
+++ b/twitter_ads/http.py
@@ -89,6 +89,7 @@ class Request(object):
         retry_on_status = self._client.options.get('retry_on_status', [500, 503])
         retry_count = 0
         retry_after = None
+        timeout = self._client.options.get('timeout', None)
 
         consumer = OAuth1Session(
             self._client.consumer_key,
@@ -101,7 +102,7 @@ class Request(object):
 
         while (retry_count <= retry_max):
             response = method(url, headers=headers, data=data, params=params,
-                              files=files, stream=stream)
+                              files=files, stream=stream, timeout=timeout)
             # do not retry on 2XX status code
             if 200 <= response.status_code < 300:
                 break


### PR DESCRIPTION
Hi team,

Sometimes I got an error caused by network connection from the API.
e.g. urllib3.exceptions.ConnectTimeoutError

I think we can add timeout option to Request class for better error handling.

Thanks,