### PR TITLE
Add GatewayTimeout to defined errors

### DIFF
--- a/twitter_ads/error.py
+++ b/twitter_ads/error.py
@@ -96,6 +96,10 @@ class ServiceUnavailable(ServerError):
         return self._retry_after
 
 
+class GatewayTimeout(Error):
+    """Gateway Timeout (504)."""
+
+
 ERRORS = {
     400: BadRequest,
     401: NotAuthorized,
@@ -103,5 +107,6 @@ ERRORS = {
     404: NotFound,
     429: RateLimit,
     500: ServerError,
-    503: ServiceUnavailable
+    503: ServiceUnavailable,
+    504: GatewayTimeout
 }


### PR DESCRIPTION
Hi, I found undefined key error in SDK.

```
[ERROR] KeyError: 504
Traceback (most recent call last):

...snip(our private code paths are included)...

  File "/var/task/twitter_ads/analytics.py", line 116, in async_stats_job_data
    raw_body=True, stream=True).perform()
  File "/var/task/twitter_ads/http.py", line 69, in perform
    raise Error.from_response(response)
  File "/var/task/twitter_ads/error.py", line 45, in from_response
    return ERRORS[response.code](response)
```

I guess we should care 504 error for the better developer experiece.