### PR TITLE
Support for new cards endpoint

### DIFF
--- a/examples/cards.py
+++ b/examples/cards.py
@@ -1,0 +1,29 @@
+from twitter_ads.client import Client
+from twitter_ads.creative import Card
+from twitter_ads.campaign import Tweet
+from twitter_ads.restapi import UserIdLookup
+
+
+CONSUMER_KEY = 'your consumer key'
+CONSUMER_SECRET = 'your consumer secret'
+ACCESS_TOKEN = 'access token'
+ACCESS_TOKEN_SECRET = 'access token secret'
+ACCOUNT_ID = 'account id'
+
+# initialize the client
+client = Client(CONSUMER_KEY, CONSUMER_SECRET, ACCESS_TOKEN, ACCESS_TOKEN_SECRET)
+
+# load the advertiser account instance
+account = client.accounts(ACCOUNT_ID)
+
+# create the card
+name = 'video website card'
+components = [{"type":"MEDIA","media_key":"13_1191948012077092867"},{"type":"DETAILS","title":"Twitter","destination":{"type":"WEBSITE", "url":"http://twitter.com/"}}]
+video_website_card = Card.create(account, name=name, components=components)
+
+# get user_id for as_user_id parameter
+user_id = UserIdLookup.load(account, screen_name='your_twitter_handle_name').id
+
+# create a tweet using this new card
+Tweet.create(account, text='Created from the SDK', as_user_id=user_id, card_uri=video_website_card.card_uri)
+# https://twitter.com/apimctestface/status/1372283476615958529

--- a/twitter_ads/account.py
+++ b/twitter_ads/account.py
@@ -10,7 +10,7 @@ from twitter_ads import API_VERSION
 
 from twitter_ads.resource import resource_property, Resource
 from twitter_ads.creative import (AccountMedia, MediaCreative, ScheduledTweet,
-                                  VideoWebsiteCard, PromotedTweet)
+                                  Card, VideoWebsiteCard, PromotedTweet)
 from twitter_ads.audience import TailoredAudience
 from twitter_ads.campaign import (AppList, Campaign, FundingInstrument, LineItem,
                                   PromotableUser, ScheduledPromotedTweet)
@@ -153,6 +153,12 @@ class Account(Resource):
         Returns a collection of video website cards available to the current account.
         """
         return self._load_resource(VideoWebsiteCard, id, **kwargs)
+
+    def cards(self, id=None, **kwargs):
+        """
+        Returns a collection of Cards available to the current account.
+        """
+        return self._load_resource(Card, id, **kwargs)
 
 
 # account properties

--- a/twitter_ads/creative.py
+++ b/twitter_ads/creative.py
@@ -621,6 +621,7 @@ class Card(Resource):
     def reload(klass):
         raise AttributeError("'Card' object has no attribute 'reload'")
 
+
 # card properties
 # read-only
 resource_property(Card, 'card_uri', readonly=True)

--- a/twitter_ads/creative.py
+++ b/twitter_ads/creative.py
@@ -604,6 +604,7 @@ class Card(Resource):
 
     RESOURCE_COLLECTION = '/' + API_VERSION + '/accounts/{account_id}/cards'
 
+    @classmethod
     def create(klass, account, name, components):
         method = 'post'
         resource = klass.RESOURCE_COLLECTION.format(account_id=account.id)
@@ -613,7 +614,7 @@ class Card(Resource):
             account.client, method, resource,
             headers=headers, body=json.dumps(payload)
         ).perform()
-        return response.body['data']
+        return klass(account).from_response(response.body['data'])
 
     def load(klass):
         raise AttributeError("'Card' object has no attribute 'load'")

--- a/twitter_ads/creative.py
+++ b/twitter_ads/creative.py
@@ -2,6 +2,7 @@
 
 """Container for all creative management logic used by the Ads API SDK."""
 
+import json
 from requests.exceptions import HTTPError
 from twitter_ads import API_VERSION
 from twitter_ads.cursor import Cursor
@@ -595,3 +596,37 @@ class Tweets(object):
         resource = klass.RESOURCE_COLLECTION.format(account_id=account.id)
         request = Request(account.client, 'get', resource, params=kwargs)
         return Cursor(None, request)
+
+
+class Card(Resource):
+
+    PROPERTIES = {}
+
+    RESOURCE_COLLECTION = '/' + API_VERSION + '/accounts/{account_id}/cards'
+
+    def create(klass, account, name, components):
+        method = 'post'
+        resource = klass.RESOURCE_COLLECTION.format(account_id=account.id)
+        headers = {'Content-Type': 'application/json'}
+        payload = {'name': name, 'components': components}
+        response = Request(
+            account.client, method, resource,
+            headers=headers, body=json.dumps(payload)
+        ).perform()
+        return response.body['data']
+
+    def load(klass):
+        raise AttributeError("'Card' object has no attribute 'load'")
+
+    def reload(klass):
+        raise AttributeError("'Card' object has no attribute 'reload'")
+
+# card properties
+# read-only
+resource_property(Card, 'card_uri', readonly=True)
+resource_property(Card, 'created_at', readonly=True, transform=TRANSFORM.TIME)
+resource_property(Card, 'deleted', readonly=True, transform=TRANSFORM.BOOL)
+resource_property(Card, 'updated_at', readonly=True, transform=TRANSFORM.TIME)
+# these are writable, but not in the sense that they can be set on an object and then saved
+resource_property(Card, 'name', readonly=True)
+resource_property(Card, 'components', readonly=True, transform=TRANSFORM.LIST)

--- a/twitter_ads/resource.py
+++ b/twitter_ads/resource.py
@@ -78,10 +78,6 @@ class Resource(object):
 
             if isinstance(value, datetime):
                 params[name] = format_time(value)
-            elif isinstance(value, list):
-                if not value:
-                    continue
-                params[name] = ','.join(map(str, value))
             elif isinstance(value, bool):
                 params[name] = str(value).lower()
             else:


### PR DESCRIPTION
Adding support for the [new Cards endpoints](https://developer.twitter.com/en/docs/twitter-ads-api/creatives/api-reference/cards), announced [here](https://twittercommunity.com/t/new-cards-endpoints-and-carousel-ads/145782).

Usage example (create):
```python
>>> name = "example"
>>> components = [{"type":"MEDIA","media_key":"13_1191948012077092867"},{"type":"DETAILS","title":"Twitter Web","destination":{"type":"WEBSITE", "url":"http://twitter.com/"}}]
>>> Card.create(account, name=name, components=components)
```