### PR TITLE
Revert deprecated Cards endpoints

### DIFF
--- a/examples/promoted_tweet.py
+++ b/examples/promoted_tweet.py
@@ -2,7 +2,7 @@
 
 from twitter_ads.client import Client
 from twitter_ads.campaign import Tweet
-from twitter_ads.creative import Card, PromotedTweet
+from twitter_ads.creative import PromotedTweet, WebsiteCard
 from twitter_ads.restapi import UserIdLookup
 
 CONSUMER_KEY = 'your consumer key'
@@ -26,13 +26,13 @@ line_item = account.line_items(None, campaign_ids=campaign.id).next()
 # create request for a simple nullcasted tweet
 tweet1 = Tweet.create(account, text='There can be only one...', as_user_id=user_id)
 
-# create request for a nullcasted tweet with a card
-card = Card.all(account).next()
+# create request for a nullcasted tweet with a website card
+website_card = WebsiteCard.all(account).next()
 tweet2 = Tweet.create(
     account,
     text='Fine. There can be two.',
     as_user_id=user_id,
-    card_uri=card.card_uri)
+    card_uri=website_card.card_uri)
 
 # promote the tweet using our line item
 tweet_ids = [tweet1['id'], tweet2['id']]

--- a/twitter_ads/__init__.py
+++ b/twitter_ads/__init__.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2015 Twitter, Inc.
 
-VERSION = (9, 0, 0)
+VERSION = (9, 0, 1)
 API_VERSION = '9'
 
 from twitter_ads.utils import get_version

--- a/twitter_ads/account.py
+++ b/twitter_ads/account.py
@@ -10,7 +10,7 @@ from twitter_ads import API_VERSION
 
 from twitter_ads.resource import resource_property, Resource
 from twitter_ads.creative import (AccountMedia, MediaCreative, ScheduledTweet,
-                                  Card, PromotedTweet)
+                                  Card, VideoWebsiteCard, PromotedTweet)
 from twitter_ads.audience import CustomAudience
 from twitter_ads.campaign import (AppList, Campaign, FundingInstrument, LineItem,
                                   PromotableUser, ScheduledPromotedTweet)
@@ -147,6 +147,12 @@ class Account(Resource):
         Returns a collection of Scheduled Promoted Tweets available to the current account.
         """
         return self._load_resource(ScheduledPromotedTweet, id, **kwargs)
+
+    def video_website_cards(self, id=None, **kwargs):
+        """
+        Returns a collection of video website cards available to the current account.
+        """
+        return self._load_resource(VideoWebsiteCard, id, **kwargs)
 
     def cards(self, id=None, **kwargs):
         """

--- a/twitter_ads/creative.py
+++ b/twitter_ads/creative.py
@@ -126,6 +126,132 @@ resource_property(MediaCreative, 'landing_url')
 resource_property(MediaCreative, 'line_item_id')
 
 
+class WebsiteCard(Resource, Persistence):
+
+    PROPERTIES = {}
+
+    RESOURCE_COLLECTION = '/' + API_VERSION + '/accounts/{account_id}/cards/website'
+    RESOURCE = '/' + API_VERSION + '/accounts/{account_id}/cards/website/{id}'
+
+
+# website card properties
+# read-only
+resource_property(WebsiteCard, 'card_type', readonly=True)
+resource_property(WebsiteCard, 'card_uri', readonly=True)
+resource_property(WebsiteCard, 'created_at', readonly=True, transform=TRANSFORM.TIME)
+resource_property(WebsiteCard, 'id', readonly=True)
+resource_property(WebsiteCard, 'media_url', readonly=True)
+resource_property(WebsiteCard, 'image_display_height', readonly=True)
+resource_property(WebsiteCard, 'image_display_width', readonly=True)
+resource_property(WebsiteCard, 'deleted', readonly=True, transform=TRANSFORM.BOOL)
+resource_property(WebsiteCard, 'website_dest_url', readonly=True)
+resource_property(WebsiteCard, 'website_display_url', readonly=True)
+resource_property(WebsiteCard, 'updated_at', readonly=True, transform=TRANSFORM.TIME)
+# writable
+resource_property(WebsiteCard, 'media_key')
+resource_property(WebsiteCard, 'name')
+resource_property(WebsiteCard, 'website_title')
+resource_property(WebsiteCard, 'website_url')
+
+
+class VideoWebsiteCard(Resource, Persistence):
+
+    PROPERTIES = {}
+
+    RESOURCE_COLLECTION = '/' + API_VERSION + '/accounts/{account_id}/cards/video_website'
+    RESOURCE = '/' + API_VERSION + '/accounts/{account_id}/cards/video_website/{id}'
+
+
+# video website card properties
+# read-only
+resource_property(VideoWebsiteCard, 'account_id', readonly=True)
+resource_property(VideoWebsiteCard, 'card_type', readonly=True)
+resource_property(VideoWebsiteCard, 'card_uri', readonly=True)
+resource_property(VideoWebsiteCard, 'created_at', readonly=True, transform=TRANSFORM.TIME)
+resource_property(VideoWebsiteCard, 'deleted', readonly=True, transform=TRANSFORM.BOOL)
+resource_property(VideoWebsiteCard, 'id', readonly=True)
+resource_property(VideoWebsiteCard, 'updated_at', readonly=True, transform=TRANSFORM.TIME)
+resource_property(VideoWebsiteCard, 'video_height', readonly=True)
+resource_property(VideoWebsiteCard, 'video_owner_id', readonly=True)
+resource_property(VideoWebsiteCard, 'video_poster_height', readonly=True)
+resource_property(VideoWebsiteCard, 'poster_media_url', readonly=True)
+resource_property(VideoWebsiteCard, 'video_poster_width', readonly=True)
+resource_property(VideoWebsiteCard, 'media_url', readonly=True)
+resource_property(VideoWebsiteCard, 'video_width', readonly=True)
+resource_property(VideoWebsiteCard, 'website_dest_url', readonly=True)
+resource_property(VideoWebsiteCard, 'website_display_url', readonly=True)
+# writable
+resource_property(VideoWebsiteCard, 'name')
+resource_property(VideoWebsiteCard, 'title')
+resource_property(VideoWebsiteCard, 'media_key')
+resource_property(VideoWebsiteCard, 'website_url')
+
+
+class ImageAppDownloadCard(Resource, Persistence):
+
+    PROPERTIES = {}
+
+    RESOURCE_COLLECTION = '/' + API_VERSION + '/accounts/{account_id}/cards/image_app_download'
+    RESOURCE = '/' + API_VERSION + '/accounts/{account_id}/cards/image_app_download/{id}'
+
+
+# image app download card properties
+# read-only
+resource_property(ImageAppDownloadCard, 'id', readonly=True)
+resource_property(ImageAppDownloadCard, 'image_display_height', readonly=True)
+resource_property(ImageAppDownloadCard, 'image_display_width', readonly=True)
+resource_property(ImageAppDownloadCard, 'media_url', readonly=True)
+resource_property(ImageAppDownloadCard, 'card_uri', readonly=True)
+resource_property(ImageAppDownloadCard, 'card_type', readonly=True)
+resource_property(ImageAppDownloadCard, 'created_at', readonly=True, transform=TRANSFORM.TIME)
+resource_property(ImageAppDownloadCard, 'updated_at', readonly=True, transform=TRANSFORM.TIME)
+resource_property(ImageAppDownloadCard, 'deleted', readonly=True, transform=TRANSFORM.BOOL)
+# writable
+resource_property(ImageAppDownloadCard, 'country_code')
+resource_property(ImageAppDownloadCard, 'app_cta')
+resource_property(ImageAppDownloadCard, 'iphone_app_id')
+resource_property(ImageAppDownloadCard, 'iphone_deep_link')
+resource_property(ImageAppDownloadCard, 'ipad_app_id')
+resource_property(ImageAppDownloadCard, 'ipad_deep_link')
+resource_property(ImageAppDownloadCard, 'googleplay_app_id')
+resource_property(ImageAppDownloadCard, 'googleplay_deep_link')
+resource_property(ImageAppDownloadCard, 'name')
+resource_property(ImageAppDownloadCard, 'media_key')
+
+
+class VideoAppDownloadCard(Resource, Persistence):
+
+    PROPERTIES = {}
+
+    RESOURCE_COLLECTION = '/' + API_VERSION + '/accounts/{account_id}/cards/video_app_download'
+    RESOURCE = '/' + API_VERSION + '/accounts/{account_id}/cards/video_app_download/{id}'
+
+
+# video app download card properties
+# read-only
+resource_property(VideoAppDownloadCard, 'card_uri', readonly=True)
+resource_property(VideoAppDownloadCard, 'card_type', readonly=True)
+resource_property(VideoAppDownloadCard, 'created_at', readonly=True, transform=TRANSFORM.TIME)
+resource_property(VideoAppDownloadCard, 'deleted', readonly=True, transform=TRANSFORM.BOOL)
+resource_property(VideoAppDownloadCard, 'id', readonly=True)
+resource_property(VideoAppDownloadCard, 'updated_at', readonly=True, transform=TRANSFORM.TIME)
+resource_property(VideoAppDownloadCard, 'video_owner_id', readonly=True)
+resource_property(VideoAppDownloadCard, 'poster_media_url', readonly=True)
+resource_property(VideoAppDownloadCard, 'media_url', readonly=True)
+# writable
+resource_property(VideoAppDownloadCard, 'country_code')
+resource_property(VideoAppDownloadCard, 'app_cta')
+resource_property(VideoAppDownloadCard, 'poster_media_key')
+resource_property(VideoAppDownloadCard, 'ipad_app_id')
+resource_property(VideoAppDownloadCard, 'ipad_deep_link')
+resource_property(VideoAppDownloadCard, 'iphone_app_id')
+resource_property(VideoAppDownloadCard, 'iphone_deep_link')
+resource_property(VideoAppDownloadCard, 'googleplay_app_id')
+resource_property(VideoAppDownloadCard, 'googleplay_deep_link')
+resource_property(VideoAppDownloadCard, 'name')
+resource_property(VideoAppDownloadCard, 'media_key')
+
+
 class ImageConversationCard(Resource, Persistence):
 
     PROPERTIES = {}


### PR DESCRIPTION
The legacy Cards API endpoints will now be [supported into v10](https://twittercommunity.com/t/website-and-app-card-endpoints-available-in-v9-sunset-postponed/156871/2). This commit reverts the commit to remove them.