### PR TITLE
[v10] Tracking Tags and minor field changes

### DIFF
--- a/twitter_ads/account.py
+++ b/twitter_ads/account.py
@@ -13,7 +13,7 @@ from twitter_ads.creative import (AccountMedia, MediaCreative, ScheduledTweet,
                                   Card, VideoWebsiteCard, PromotedTweet)
 from twitter_ads.audience import CustomAudience
 from twitter_ads.campaign import (AppList, Campaign, FundingInstrument, LineItem,
-                                  PromotableUser, ScheduledPromotedTweet)
+                                  PromotableUser, TrackingTags, ScheduledPromotedTweet)
 
 
 class Account(Resource):
@@ -147,6 +147,12 @@ class Account(Resource):
         Returns a collection of Scheduled Promoted Tweets available to the current account.
         """
         return self._load_resource(ScheduledPromotedTweet, id, **kwargs)
+
+    def tracking_tags(self, id=None, **kwargs):
+        """
+        Returns a collection of Tracking Tags available to the current account.
+        """
+        return self._load_resource(TrackingTags, id, **kwargs)
 
     def video_website_cards(self, id=None, **kwargs):
         """

--- a/twitter_ads/campaign.py
+++ b/twitter_ads/campaign.py
@@ -141,7 +141,6 @@ resource_property(TargetingCriteria, 'line_item_id')
 resource_property(TargetingCriteria, 'operator_type')
 resource_property(TargetingCriteria, 'targeting_type')
 resource_property(TargetingCriteria, 'targeting_value')
-resource_property(TargetingCriteria, 'custom_audience_expansion')
 # sdk-only
 resource_property(TargetingCriteria, 'to_delete', transform=TRANSFORM.BOOL)
 

--- a/twitter_ads/campaign.py
+++ b/twitter_ads/campaign.py
@@ -359,6 +359,26 @@ resource_property(ScheduledPromotedTweet, 'line_item_id')
 resource_property(ScheduledPromotedTweet, 'scheduled_tweet_id')
 
 
+class TrackingTags(Resource, Persistence):
+
+    PROPERTIES = {}
+
+    RESOURCE_COLLECTION = '/' + API_VERSION + '/accounts/{account_id}/tracking_tags'
+    RESOURCE = '/' + API_VERSION + '/accounts/{account_id}/tracking_tags/{id}'
+
+
+# tracking tags properties
+# read-only
+resource_property(TrackingTags, 'created_at', readonly=True, transform=TRANSFORM.TIME)
+resource_property(TrackingTags, 'id', readonly=True)
+resource_property(TrackingTags, 'deleted', readonly=True, transform=TRANSFORM.BOOL)
+resource_property(TrackingTags, 'updated_at', readonly=True, transform=TRANSFORM.TIME)
+# writable
+resource_property(TrackingTags, 'line_item_id')
+resource_property(TrackingTags, 'tracking_tag_type')
+resource_property(TrackingTags, 'tracking_tag_url')
+
+
 class Tweet(object):
 
     TWEET_CREATE = '/' + API_VERSION + '/accounts/{account_id}/tweet'

--- a/twitter_ads/creative.py
+++ b/twitter_ads/creative.py
@@ -626,6 +626,7 @@ class Card(Resource):
 # card properties
 # read-only
 resource_property(Card, 'card_uri', readonly=True)
+resource_property(Card, 'card_type', readonly=True)
 resource_property(Card, 'created_at', readonly=True, transform=TRANSFORM.TIME)
 resource_property(Card, 'deleted', readonly=True, transform=TRANSFORM.BOOL)
 resource_property(Card, 'updated_at', readonly=True, transform=TRANSFORM.TIME)


### PR DESCRIPTION
Adds supports for the new [Tracking Tags](https://developer.twitter.com/en/docs/twitter-ads-api/campaign-management/api-reference/tracking-tags) endpoints. Adds `card_type` to cards response and removes `custom_audience_expansion` field from targeting.